### PR TITLE
Improve reset handling in nasti components

### DIFF
--- a/nasti/nasti_demux.sv
+++ b/nasti/nasti_demux.sv
@@ -74,14 +74,15 @@ module nasti_demux
 
    assign aw_port_sel = lock ? locked_port : port_match(master.aw_addr);
 
-   always_ff @(posedge clk or negedge rstn)
-     if(!rstn)
-       lock <= 1'b0;
-     else if(master.aw_valid && master.aw_ready) begin
-        lock <= 1'b1;
-        locked_port <= aw_port_sel;
-     end else if((LITE_MODE || master.w_last) && master.w_valid && master.w_ready)
-       lock <= 1'b0;
+   always_ff @(posedge clk or negedge rstn) begin
+      if(master.aw_valid && master.aw_ready) begin
+         lock <= 1'b1;
+         locked_port <= aw_port_sel;
+      end else if((LITE_MODE || master.w_last) && master.w_valid && master.w_ready)
+	lock <= 1'b0;
+      if(!rstn)
+	lock <= 1'b0;
+   end
 
    generate
       for(i=0; i<8; i++) begin

--- a/nasti/nasti_lite_writer.sv
+++ b/nasti/nasti_lite_writer.sv
@@ -132,20 +132,20 @@ module nasti_lite_writer
    assign aw_buf_full = aw_buf_valid && aw_buf_wp == aw_buf_rp;
    assign aw_buf_empty = !aw_buf_valid && aw_buf_wp == aw_buf_rp;
 
-   always_ff @(posedge clk or negedge rstn)
-     if(!rstn)
+   always_ff @(posedge clk or negedge rstn) begin
+      if(nasti_aw_valid && nasti_aw_ready) begin
+         aw_buf[aw_buf_wp] <= NastiReq'{nasti_aw_id, nasti_aw_addr, nasti_aw_len,
+					nasti_aw_size, nasti_aw_burst, nasti_aw_lock,
+					nasti_aw_cache, nasti_aw_prot, nasti_aw_qos,
+					nasti_aw_region, nasti_aw_user};
+         aw_buf_wp <= incr(aw_buf_wp, 1, MAX_TRANSACTION);
+
+         assert(nasti_aw_burst == 2'b01)
+           else $fatal(1, "nasti-lite support only INCR burst!");
+      end
+      if(!rstn)
         aw_buf_wp <= 0;
-     else if(nasti_aw_valid && nasti_aw_ready) begin
-        aw_buf[aw_buf_wp] <= NastiReq'{nasti_aw_id, nasti_aw_addr, nasti_aw_len,
-                                       nasti_aw_size, nasti_aw_burst, nasti_aw_lock,
-                                       nasti_aw_cache, nasti_aw_prot, nasti_aw_qos,
-                                       nasti_aw_region, nasti_aw_user};
-        aw_buf_wp <= incr(aw_buf_wp, 1, MAX_TRANSACTION);
-
-        assert(nasti_aw_burst == 2'b01)
-          else $fatal(1, "nasti-lite support only INCR burst!");
-
-     end
+   end
 
    always_ff @(posedge clk or negedge rstn)
      if(!rstn)
@@ -218,20 +218,18 @@ module nasti_lite_writer
      end else if(xact_finish)
        xact_b_cnt <= 0;
 
-   always_ff @(posedge clk or negedge rstn)
-     if(!rstn)
-       xact_req_valid <= 1'b0;
-     else if(xact_finish || !xact_req_valid) begin
-        if(aw_buf_valid)
-          xact_req <= aw_buf[aw_buf_rp];
-        xact_req_valid <= aw_buf_valid;
-     end
+   always_ff @(posedge clk or negedge rstn) begin
+      if(xact_finish || !xact_req_valid) begin
+         if(aw_buf_valid)
+           xact_req <= aw_buf[aw_buf_rp];
+         xact_req_valid <= aw_buf_valid;
+      end
+      if(!rstn)
+	xact_req_valid <= 1'b0;
+   end
 
-   always_ff @(posedge clk or negedge rstn)
-     if(!rstn) begin
-        lite_aw_data_valid <= 1'b0;
-        lite_b_data_valid <= 1'b0;
-     end else if(nasti_w_valid && nasti_w_ready) begin
+   always_ff @(posedge clk or negedge rstn) begin
+     if(nasti_w_valid && nasti_w_ready) begin
         xact_data_vec <= nasti_w_data;
         xact_strb_vec <= nasti_w_strb;
         xact_user <= nasti_w_user;
@@ -244,6 +242,11 @@ module nasti_lite_writer
         if((lite_b_valid && lite_b_ready || lite_b_bypass) && lite_b_cnt == lite_packet_ratio(xact_req)-1)
           lite_b_data_valid <= 1'b0;
      end
+     if(!rstn) begin
+        lite_aw_data_valid <= 1'b0;
+        lite_b_data_valid <= 1'b0;
+     end
+   end
 
    always_ff @(posedge clk)
      if(lite_b_valid && lite_b_ready)

--- a/nasti/nasti_mux.sv
+++ b/nasti/nasti_mux.sv
@@ -90,14 +90,15 @@ module nasti_mux
 
    assign aw_port_sel = lock ? locked_port : toInt(aw_gnt);
 
-   always_ff @(posedge clk or negedge rstn)
-     if(!rstn)
-       lock <= 1'b0;
-     else if(master.aw_valid[aw_port_sel] && master.aw_ready[aw_port_sel]) begin
-        lock <= 1'b1;
-        locked_port <= aw_port_sel;
-     end else if((LITE_MODE || master.w_last[aw_port_sel]) && master.w_valid[aw_port_sel] && master.w_ready[aw_port_sel])
-       lock <= 1'b0;
+   always_ff @(posedge clk or negedge rstn) begin
+      if(master.aw_valid[aw_port_sel] && master.aw_ready[aw_port_sel]) begin
+         lock <= 1'b1;
+         locked_port <= aw_port_sel;
+      end else if((LITE_MODE || master.w_last[aw_port_sel]) && master.w_valid[aw_port_sel] && master.w_ready[aw_port_sel])
+	lock <= 1'b0;
+      if(!rstn)
+	lock <= 1'b0;
+   end
 
    assign slave.aw_id      = master.aw_id[aw_port_sel];
    assign slave.aw_addr    = master.aw_addr[aw_port_sel];
@@ -139,19 +140,17 @@ module nasti_mux
    assign slave.b_ready = master.b_ready[write_vec_port[write_match_index]];
 
    // update write_vec
-   always_ff @(posedge clk or negedge rstn)
-     if(!rstn) begin
-        write_vec_valid <= 0;
-     end else begin
-        if(slave.aw_valid && slave.aw_ready) begin
-           write_vec_id[write_wp] <= slave.aw_id;
-           write_vec_port[write_wp] <= aw_port_sel;
-           write_vec_valid[write_wp] <= 1'b1;
-        end
-
-        if(slave.b_valid && slave.b_ready)
-          write_vec_valid[write_match_index] <= 1'b0;
-     end
+   always_ff @(posedge clk or negedge rstn) begin
+      if(slave.aw_valid && slave.aw_ready) begin
+         write_vec_id[write_wp] <= slave.aw_id;
+         write_vec_port[write_wp] <= aw_port_sel;
+         write_vec_valid[write_wp] <= 1'b1;
+      end
+      if(slave.b_valid && slave.b_ready)
+        write_vec_valid[write_match_index] <= 1'b0;
+     if(!rstn)
+       write_vec_valid <= 0;
+   end
 
    // AR and R
    logic [2:0] ar_port_sel;
@@ -202,20 +201,20 @@ module nasti_mux
    assign slave.r_ready = master.r_ready[read_vec_port[read_match_index]];
 
    // update read_vec
-   always_ff @(posedge clk or negedge rstn)
-     if(!rstn) begin
-        int n;
-        for(n=0; n<R_MAX; n++)
-          read_vec_valid[n] <= 1'b0;
-     end else begin
-        if(slave.ar_valid && slave.ar_ready) begin
-           read_vec_id[read_wp] <= slave.ar_id;
-           read_vec_port[read_wp] <= ar_port_sel;
-           read_vec_valid[read_wp] <= 1'b1;
-        end
+   always_ff @(posedge clk or negedge rstn) begin
+      if(slave.ar_valid && slave.ar_ready) begin
+         read_vec_id[read_wp] <= slave.ar_id;
+         read_vec_port[read_wp] <= ar_port_sel;
+         read_vec_valid[read_wp] <= 1'b1;
+      end
 
-        if(slave.r_valid && slave.r_ready)
-          read_vec_valid[read_match_index] <= 1'b0;
-     end
+      if(slave.r_valid && slave.r_ready)
+        read_vec_valid[read_match_index] <= 1'b0;
+      if(!rstn) begin
+         int n;
+         for(n=0; n<R_MAX; n++)
+           read_vec_valid[n] <= 1'b0;
+      end
+   end
 
 endmodule // nasti_mux


### PR DESCRIPTION
This patch silences Vivado warnings like:
WARNING: [Synth 8-5788] Register xact_req_reg[id] in module nasti_lite_writer is has both Set and reset with same priority. This may cause simulation mismatches. Consider rewriting code

It likely also improves performance by avoiding an extra CE pin load on
the reset net

More info about the reset method at http://olofkindgren.blogspot.com/2017/11/resetting-reset-handling.html
Synthesis fails on Vivado 2017.3 without this patch